### PR TITLE
Edit nginx redirects & config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,10 +9,11 @@ const config = {
   title: 'Civo Documentation',
   tagline: 'The Cloud Native Service Provider',
   url: 'https://www.civo.com',
-  baseUrl: '/docs/',
+  baseUrl: '/docs',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',
   favicon: 'img/favicon.ico',
+  trailingSlash: false,
 
   presets: [
     [

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,17 +19,12 @@ http {
     # Docusaurus redirects
     rewrite ^/docs/$ /docs permanent;
     rewrite ^/docs/(.*)/$ /docs/$1 permanent;
-    rewrite ^/docs/overview$ /docs/overview/introduction-getting-started permanent;
-    rewrite ^/docs/account$ /docs/account/signing-up permanent;
-    rewrite ^/docs/compute$ /docs/compute/instances-introduction permanent;
-    rewrite ^/docs/kubernetes$ /docs/kubernetes/kubernetes-introduction permanent;
-    rewrite ^/docs/networking$ /docs/networking/networking-introduction permanent;
 
     ##
     # OLD DOC REDIRECTS
 
     # Quick start
-    rewrite ^/docs/quick-start$ /docs/overview/introduction-getting-started permanent;
+    rewrite ^/docs/quick-start$ /docs/overview permanent;
     rewrite ^/docs/quick-start/600$ /docs/kubernetes/create-a-cluster permanent;
     rewrite ^/docs/quick-start/578$ /docs/compute/create-an-instance permanent;
     rewrite ^/docs/quick-start/580$ /docs/compute/create-an-instance permanent;


### PR DESCRIPTION
Remove nginx redirects now that the /compute and /account headers direct to their respective index files.

Try to solve the trailing slash issue by making the `trailingSlash` option false.