### PR TITLE
chore: fix typo

### DIFF
--- a/content/docs/kubernetes/create-a-cluster.md
+++ b/content/docs/kubernetes/create-a-cluster.md
@@ -164,7 +164,7 @@ Applications:
 You can see that the four nodes that were requested are running, they are the size they were specified to be above, and the cluster has the default installed applications, *Traefik* and the Kubernetes *metrics-server* up as well. Any changes, such as scaling your cluster up/down, will be immediately reflected on this status screen as shown in the *BUILDING* state of the two nodes.
 
 :::note
-Tou will need to have set the correct [Civo region](../overview/regions.md) for where the cluster was created when you [set up Civo CLI](../overview/civo-cli.md), or specify it in the command with `--region` to be able to view the cluster information.
+You will need to have set the correct [Civo region](../overview/regions.md) for where the cluster was created when you [set up Civo CLI](../overview/civo-cli.md), or specify it in the command with `--region` to be able to view the cluster information.
 :::
 
 </TabItem>


### PR DESCRIPTION
This PR fixes a typo in "Create a cluster" document.