### PR TITLE
fix: invalid command

### DIFF
--- a/content/docs/database/postgresql/connect.md
+++ b/content/docs/database/postgresql/connect.md
@@ -41,7 +41,7 @@ civo database list
 To get the credentials of a specific database, use:
 
 ```bash
-civo database show [Database_Name] --credentials
+civo db credential [Database_Name]
 ```
 
 ![psql database show](../images/psql-database-show.png)


### PR DESCRIPTION
The command from the [docs](https://www.civo.com/docs/database/postgresql/connect) page threw an error:

Version: `Civo CLI v1.0.81`

```
civo database show [Database_Name] --credentials
Error: unknown flag: --credentials
```

The command suggested using:

```
To get the credentials, run : civo db credential [Database_Name]
```