### PR TITLE
added manual override for the dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.1.1"
   },
+  "resolutions": {
+    "path-to-regexp": "^3.3.0"
+  },
   "browserslist": {
     "production": [
       ">0.5%",


### PR DESCRIPTION
added resolutions field to `package.json` to force all deps to use the patched version of `path-to-regex`.