### PR TITLE
correcting autoscaling tf example for accuracy

### DIFF
--- a/content/docs/kubernetes/scaling-nodes.md
+++ b/content/docs/kubernetes/scaling-nodes.md
@@ -139,11 +139,15 @@ To add the cluster autoscaler application via Terraform, include it in the `appl
 ```terraform
 resource "civo_kubernetes_cluster" "cluster" {
   name              = "<name you want to give your cluster>"
-  cluster_type      = "k3s" # Your choice of cluster type, can be k3s or talos
+  cluster_type      = "k3s" # k3s or talos
   applications      = "civo-cluster-autoscaler"
-  num_target_nodes  = 3
-  target_nodes_size = element(data.civo_instances_size.small.sizes, 0).name
-  region            = "NYC1" # Your choice of Civo region
+  network_id        = civo_network.example.id # replace with your network reference
+  firewall_id       = civo_firewall.example.id # replace with your firewall reference
+  pools {
+      label = "pool-name"
+      size = "g4s.kube.small"
+      node_count = 3
+  }
 }
 ```
 


### PR DESCRIPTION
A question came into the civo community workspace after referencing some terraform code in our docs that has fallen stale.
https://civo-community.slack.com/archives/CMVCKMCN5/p1744143215781549

The example in the docs doesn't accurately represent the latest terraform module for the civo_kubernetes_cluster resource properties. The node pool concept has since been added and the docs should reflect this adjustment.