### PR TITLE
CLI instructions for console access / compute instance placement rules for CSE regions

### DIFF
--- a/content/docs/compute/compute-instance-placement-rules.md
+++ b/content/docs/compute/compute-instance-placement-rules.md
@@ -1,0 +1,167 @@
+---
+sidebar_position: 8
+title: Compute instance placement rules
+description: Learn how to manage compute instance placement rules on CivoStack Enterprise regions
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<head>
+  <title>Managing compute instance placement rules on CivoStack Enterprise regions | Civo Documentation</title>
+</head>
+
+:::note
+These features are only available on CivoStack Enterprise regions, and are made available by request
+:::
+
+## Overview
+
+The Placement Rules API allows customers using CivoStack Enterprise to have greater control over the scheduling of their instances within a dedicated region under their management. This API provides endpoints for listing available workload placement labels and creating instances with specific placement rules.
+
+This functionality must be specifically enabled on each private Civo Region. Contact Civo support if you manage a private Civo Region where you aim to leverage instance placement rules.
+
+The functionality regards the Workload Placement rules in general, which can be managed with some sub-functionalities:
+
+* region node labelling for underlying node selection
+* affinity and anti-affinity rules (strong and weak) of virtual machine instances.
+
+Let’s see them in detail in the following sections.
+
+## Node Selection
+
+A Civo Region is composed of multiple interconnected nodes on which cloud workloads can be scheduled.
+
+The mechanism of driving the scheduling towards a preferred node is called "node selection".
+
+Once a region is marked to support the placement rules, you can ask the Civo support team to let any number of named nodes that make up your region be labelled with tags composed of `tag-name` as a key and a corresponding `tag-value`. Each `tag-name` and `tag-value` are arbitrary strings, and are defined by you, such as:
+
+`workloadplacement.civo.io/<tag-name>: "<tag-value>"`
+
+This tag allows the node to be selectable for particular workloads when specifying the particular tag in the compute instance creation request.
+
+The following information will be based on an example region containing 5 nodes named and labelled as follows:
+
+```yaml
+nodes:
+  - node01
+    labels:
+      - workloadplacement.civo.io/os: "windows-preferred"
+  - node02
+    labels:
+      - workloadplacement.civo.io/os: "linux-preferred"
+  - node03
+    labels:
+      - workloadplacement.civo.io/os: "linux-preferred"
+      - workloadplacement.civo.io/compute: "gpu"
+  - node04
+  - node05
+```
+
+## List node selectors available in a Civo region 
+
+To list what node selectors have been made available in a Civo Region, you can use the following API call:
+
+```console
+curl -H "Authorization: Bearer {civo-API-key}" https://api.civo.com/v2/workload/placements?region={region}
+```
+
+The response will be a JSON block, such as:
+
+```json
+{
+  "workloadplacement.civo.io/compute": [
+    "gpu"
+  ],
+  "workloadplacement.civo.io/os": [
+    "windows-preferred",
+    "linux-preferred"
+  ]
+}
+```
+
+## Specify node selectors during instance creation
+
+When creating a new Civo instance in a region configured with instance placement rules, you can apply a desired node selector as follows, entering the `workloadplacement.civo.io/` tag under a `placement_rule` parameter:
+
+```console
+curl -H 'Authorization: Bearer {civo-API-key}' -X POST https://api.civo.com/v2/instances?region={region} \
+-H 'Content-Type: application/json' \
+-d '{"hostname": "windows-vm",
+    "size": "g3.small",
+    "template_id": "ad26da32-c56b-406a-a2df-471fe384c5e9",
+    "placement_rule": {
+        "node_selector": {
+              "workloadplacement.civo.io/os": "windows-preferred"
+        }
+    }
+  }'
+```
+
+This would result in an attempt to first create the instance on `node01` of the region described above, as that node is configured with the `windows-preferred` tag.
+
+## Specify affinity and anti-affinity during instance creation
+
+To drive the Civo scheduler to spin up a new instance in the same or in a different node than another running instance, you can leverage instance placement tags to specify *soft* or *hard* affinity and anti-affinity rules.
+
+The difference between the soft and hard rules is that the soft rules express a preference, but it’s not mandatory, so the rule will only be applied if possible. Conversely, when specifying a hard rule, if the condition imposed by the rule cannot be satisfied, the instance will not be scheduled and will remain in a pending state until the conditions for the rule to be applied are met.
+
+Affinity and anti-affinity rules are set using an `affinity_rules` option under the `placement_rule` parameter, in the following format:
+
+```json
+"placement_rule": {
+  "affinity_rules": [
+    {
+      "type": "affinity" / "anti-affinity",
+      "exclusive": true / false,
+      "tags": [
+        // selected workloadplacement.civo.io/ tag(s) to match this rule to
+      ] 
+    }
+  ]
+}
+```
+
+Here is an example request to create a new instance with some of these rules applied:
+
+```console
+curl -H 'Authorization: Bearer {civo-API-key}' -X POST https://api.civo.com/v2/instances?region={region} \
+-H 'Content-Type: application/json' \
+-d '{
+    "hostname": "bi-controller-vm",
+    "size": "g4g.xlarge",
+    "template_id": "ad26da32-c56b-406a-a2df-471fe384c5e9",
+    "placement_rule": {
+      "affinity_rules": [
+        {
+          "type": "affinity",
+          "exclusive": true,
+          "tags": [
+            "gpu" // tag of the instances to which set the affinity
+          ]
+        },
+        {
+          "type": "affinity",
+          "exclusive": false,
+          "tags": [
+            "batch" // tag of the instances to which set the affinity
+          ]
+        },
+        {
+        "type": "anti-affinity",
+          "exclusive": true,
+          "tags": [
+            "windows" // tag of the instances to which set the anti-affinity
+          ]
+        },
+        {
+          "type": "anti-affinity",
+          "exclusive": false,
+          "tags": [
+            "api-server" // tag of the instances to which set the anti-affinity
+          ]
+        }
+      ]
+    }
+  }'
+```

--- a/content/docs/compute/compute-instance-placement-rules.md
+++ b/content/docs/compute/compute-instance-placement-rules.md
@@ -21,13 +21,6 @@ The Placement Rules API allows customers using CivoStack Enterprise to have grea
 
 This functionality must be specifically enabled on each private Civo Region. Contact Civo support if you manage a private Civo Region where you aim to leverage instance placement rules.
 
-The functionality regards the Workload Placement rules in general, which can be managed with some sub-functionalities:
-
-* region node labelling for underlying node selection
-* affinity and anti-affinity rules (strong and weak) of virtual machine instances.
-
-Let’s see them in detail in the following sections.
-
 ## Node Selection
 
 A Civo Region is composed of multiple interconnected nodes on which cloud workloads can be scheduled.
@@ -58,7 +51,7 @@ nodes:
   - node05
 ```
 
-## List node selectors available in a Civo region 
+## List node selectors available in a Civo region
 
 To list what node selectors have been made available in a Civo Region, you can use the following API call:
 
@@ -99,69 +92,3 @@ curl -H 'Authorization: Bearer {civo-API-key}' -X POST https://api.civo.com/v2/i
 ```
 
 This would result in an attempt to first create the instance on `node01` of the region described above, as that node is configured with the `windows-preferred` tag.
-
-## Specify affinity and anti-affinity during instance creation
-
-To drive the Civo scheduler to spin up a new instance in the same or in a different node than another running instance, you can leverage instance placement tags to specify *soft* or *hard* affinity and anti-affinity rules.
-
-The difference between the soft and hard rules is that the soft rules express a preference, but it’s not mandatory, so the rule will only be applied if possible. Conversely, when specifying a hard rule, if the condition imposed by the rule cannot be satisfied, the instance will not be scheduled and will remain in a pending state until the conditions for the rule to be applied are met.
-
-Affinity and anti-affinity rules are set using an `affinity_rules` option under the `placement_rule` parameter, in the following format:
-
-```json
-"placement_rule": {
-  "affinity_rules": [
-    {
-      "type": "affinity" / "anti-affinity",
-      "exclusive": true / false,
-      "tags": [
-        // selected workloadplacement.civo.io/ tag(s) to match this rule to
-      ] 
-    }
-  ]
-}
-```
-
-Here is an example request to create a new instance with some of these rules applied:
-
-```console
-curl -H 'Authorization: Bearer {civo-API-key}' -X POST https://api.civo.com/v2/instances?region={region} \
--H 'Content-Type: application/json' \
--d '{
-    "hostname": "bi-controller-vm",
-    "size": "g4g.xlarge",
-    "template_id": "ad26da32-c56b-406a-a2df-471fe384c5e9",
-    "placement_rule": {
-      "affinity_rules": [
-        {
-          "type": "affinity",
-          "exclusive": true,
-          "tags": [
-            "gpu" // tag of the instances to which set the affinity
-          ]
-        },
-        {
-          "type": "affinity",
-          "exclusive": false,
-          "tags": [
-            "batch" // tag of the instances to which set the affinity
-          ]
-        },
-        {
-        "type": "anti-affinity",
-          "exclusive": true,
-          "tags": [
-            "windows" // tag of the instances to which set the anti-affinity
-          ]
-        },
-        {
-          "type": "anti-affinity",
-          "exclusive": false,
-          "tags": [
-            "api-server" // tag of the instances to which set the anti-affinity
-          ]
-        }
-      ]
-    }
-  }'
-```

--- a/content/docs/compute/console-access.md
+++ b/content/docs/compute/console-access.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
   <title>How to Enable Console Access on Civo Compute Instances | Civo Documentation</title>
 </head>
 
-In case you need to access an instance directly for any reason, such as SSH access not working, you can activate an instance's console access to enable you to get back to normal operation.
+In case you need to access an instance directly for any reason, such as SSH access not working, you can activate an instance's out-of-band console access to enable you to get back to normal operation.
 
 :::danger note
 Your instance must be configured to permit access through username and password to successfully be able to access it using the console. Console access to instances is intended as an emergency tool only, and does not allow for copy/paste or other conveniences.
@@ -41,6 +41,8 @@ This will open up your default web browser to the console access URL and allow y
 
 :::note
 Only one session can be active for a particular instance at a time: subsequent requests to initiate a console while a session has already been initialized will respond idempotently, returning a link to the currently active session.
+
+The console only supports one concurrent connection to the instance at any time. You can disconnect or close the browser tab if you wish to let other users interact with the instance using the web console.
 :::
 
 You can see all available options for managing console access on the CLI by running `civo instance vnc --help`.

--- a/content/docs/compute/console-access.md
+++ b/content/docs/compute/console-access.md
@@ -17,6 +17,8 @@ In case you need to access an instance directly for any reason, such as SSH acce
 Your instance must be configured to permit access through username and password to successfully be able to access it using the console. Console access to instances is intended as an emergency tool only, and does not allow for copy/paste or other conveniences.
 :::
 
+Console access can currently be enabled using the [Civo API](https://www.civo.com/api/console-access) or CLI only.
+
 <Tabs groupId="activate-console">
 
 <TabItem value="cli" label="Civo CLI">

--- a/content/docs/compute/console-access.md
+++ b/content/docs/compute/console-access.md
@@ -1,0 +1,47 @@
+---
+sidebar_position: 7
+title: Console access
+description: Learn how to access the console of a Civo Compute instance using the Civo CLI to recover from issues.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<head>
+  <title>How to Enable Console Access on Civo Compute Instances | Civo Documentation</title>
+</head>
+
+In case you need to access an instance directly for any reason, such as SSH access not working, you can activate an instance's console access to enable you to get back to normal operation.
+
+:::danger note
+Your instance must be configured to permit access through username and password to successfully be able to access it using the console. Console access to instances is intended as an emergency tool only, and does not allow for copy/paste or other conveniences.
+:::
+
+<Tabs groupId="activate-console">
+
+<TabItem value="cli" label="Civo CLI">
+
+## Activating console access on the command line
+
+If your Civo CLI is configured to act in the region where your instance is running, you can initiate a console access session by running `civo instance vnc INSTANCE_NAME` without having to provide a `--region` flag:
+
+```console
+$ civo instance vnc vnc-demo
+Info: VNC has been successfully enabled for instance: vnc-demo
+Info: VNC URL: https://vnc.lon1.civo.com/c603a1f0-cfb5-47ed-80c8-d77fe4dba385/vnc.html?path=c603a1f0-cfb5-47ed-80c8-d77fe4dba385/websockify
+Info: We're preparing the VNC Console Access. This may take a while...
+Info: New attempt to reach the VNC Console URI...
+Info: Opening VNC in your default browser...
+Info: VNC session is now active. You can access your instance's graphical interface.
+```
+
+This will open up your default web browser to the console access URL and allow you to log in using a username and password.
+
+:::note
+Only one session can be active for a particular instance at a time: subsequent requests to initiate a console while a session has already been initialized will respond idempotently, returning a link to the currently active session.
+:::
+
+You can see all available options for managing console access on the CLI by running `civo instance vnc --help`.
+
+</TabItem>
+</Tabs>


### PR DESCRIPTION
Adds instructions for accessing the instance console using the CLI, and a separate page for instance placement rules usage.