### PR TITLE
docs: update GPU operator guide with Civo-tuned flags and H100 NVLink…

### DIFF
--- a/content/docs/kubernetes/advanced/gpu-config.md
+++ b/content/docs/kubernetes/advanced/gpu-config.md
@@ -1,6 +1,6 @@
 ---
 title: GPU Clusters on Civo Kubernetes
-description: Learn more about what GPU Types are supported on Civo Kubernetes. When using GPU workloads on Civo Kubernetes clusters, you may wish to install the GPU operator in your cluster.
+description: Learn which GPU types are supported on Civo Kubernetes, how to install the NVIDIA GPU Operator with the right settings for Civo's image, and the extra step needed for single-GPU H100 nodes.
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -11,72 +11,151 @@ import TabItem from '@theme/TabItem';
 
 ## Overview
 
-Running GPU workloads on Kubernetes is becoming increasingly common due to the flexibility and scalability it provides. Deciding on the type of Kubernetes nodes for your GPU workloads involves many considerations. Whether you require low-latency responses, high-throughput inference requests, or other performance needs, Civo has you covered.
+GPU workloads on Kubernetes power everything from large-language-model training to real-time inference and 3D rendering. Civo Kubernetes lets you add GPU node pools to a cluster and run those workloads with the standard NVIDIA tooling.
+
+This page covers:
+
+- The GPU types Civo offers
+- How to install the NVIDIA GPU Operator on a Civo Kubernetes cluster
+- The extra step required for **single-GPU H100 nodes**
+- Verification and troubleshooting
 
 ## GPU Types
 
-**Civo provides the following GPU Types:**
+**Civo provides the following GPU types:**
 
-- **NVIDIA A100 Tensor Core GPU:** Available in both 40GB and 80GB variants, this GPU is designed for high-demand workloads such as machine learning model training, large language models, and scientific computing. It offers significant computational power with over 312 teraflops of FP16 performance and 1,248 Tensor cores.
-- **NVIDIA H100 Tensor Core GPU:** Known for its advanced Hopper architecture, this GPU excels in AI training and inference tasks, making it ideal for developing and deploying large AI models like chatbots and recommendation engines.
-- **NVIDIA L40S GPU:** With 48GB of GDDR6 memory, this GPU is suitable for tasks requiring a blend of AI computations and advanced graphics processing, such as 3D graphics rendering and training large language models.
-- **NVIDIA GH200 Grace Hopper Superchip:** This GPU features an integrated CPU-GPU architecture tailored for generative AI, large-scale AI inference, and high-performance computing workloads that demand substantial memory and processing power.
+- **NVIDIA A100 Tensor Core GPU** — available in 40 GB and 80 GB variants. Well suited to model training, LLMs, and scientific computing; delivers over 312 TFLOPS of FP16 performance across 1,248 Tensor cores.
+- **NVIDIA H100 Tensor Core GPU** — Hopper-generation GPU built for AI training and inference, ideal for large models such as chatbots and recommendation engines. Single-GPU H100 nodes need one extra install step — see [Single-GPU H100 nodes: NVLink workaround](#single-gpu-h100-nodes-nvlink-workaround).
+- **NVIDIA L40S GPU** — 48 GB of GDDR6 memory. A good fit for mixed AI + graphics workloads such as 3D rendering and LLM training.
+- **NVIDIA B200 Tensor Core GPU** — Blackwell-generation GPU for the most demanding training and inference workloads. Runs with the standard install shown below.
+- **NVIDIA GH200 Grace Hopper Superchip** — integrated CPU + GPU package tailored for generative AI, large-scale inference, and HPC workloads.
 
-To deploy GPU workloads on Kubernetes, [add a new node pool to your cluster](managing-node-pools.md) and refer to the details below to install the Kubernetes operator for GPU nodes.
+To use GPUs on Kubernetes, [add a GPU node pool to your cluster](managing-node-pools.md), then install the NVIDIA GPU Operator as described below.
 
 :::note
-GPU nodes for Kubernetes is a separate node SKU than traditional Kubernetes nodes.
+GPU nodes use a separate instance SKU from standard Kubernetes nodes. Pricing and availability are shown in the Civo Dashboard when you add a node pool.
 :::
 
-## Installing the NVIDIA GPU Operator on Civo Kubernetes
+## Installing the NVIDIA GPU Operator
 
-To take advantage of the Nvidia GPU in Civo Kubernetes clusters, you may wish to install a GPU operator to the cluster. This document details the following:
+The NVIDIA GPU Operator installs and manages the GPU driver, the device plugin, and GPU Feature Discovery. You install it once per cluster — after that, any GPU node pool you add is detected automatically.
 
-- Preparation of a Kubernetes cluster with a GPU node
-- Installation of the GPU operator using Helm
-- Troubleshooting
+### Before you start
 
-### Preparation
+1. **A Civo Kubernetes cluster with a GPU node pool.** If you don't have one yet, follow [Creating a Kubernetes cluster](../create-a-cluster.md) and add a GPU node pool.
+2. **The cluster's `kubeconfig`**, downloaded from the Civo Dashboard and set as your current context.
+3. **[Helm](https://helm.sh/docs/intro/install/)** installed on the machine you're running the install from.
 
-Start by creating a Kubernetes cluster and allocate a GPU node to it following the instructions [here](https://www.civo.com/docs/kubernetes/create-a-cluster).
-
-You will also need to download the KUBECONFIG for the cluster once it is running.
-
-In order to install the GPU operator, you will need to [have Helm installed](https://helm.sh/docs/intro/install/) on the machine you are working on.
-
-Now you should be able to use Kubectl to manage the Kubernetes Cluster.
-
-## Installation of the GPU operator using Helm
-
-Once your KUBECONFIG is downloaded and set as your current context,  you can run the following to deploy the GPU operator:  
-
-```bash  
-kubectl create ns gpu-operator
-
-kubectl label --overwrite ns gpu-operator pod-security.kubernetes.io/enforce=privileged
-
-helm repo add nvidia https://helm.ngc.nvidia.com/nvidia && helm repo update
-
-helm install --wait --generate-name \
--n gpu-operator --create-namespace \
-nvidia/gpu-operator
-
-```
-  
-:::note
-No upgrade the GPU operator to newer versions are needed - this process is fully automated.
-:::
-
-Once you have deployed the GPU operator, run `kubectl -n gpu-operator get pods` to verify that the GPU operator is running well:
-![List GPU Operator in Kubernetes](../images/kubectl-list-gpu-operator.png)
-
-Now you are all set to use the GPU Operator, feel free to run `kubectl describe nodes` to verify that the GPU node was indeed classified to have a GPU, you would particularly see the following in the node’s labels:
-![List NVIDIA node labels in Kubernetes](../images/k8s-gpu-node-label.png)
-
-### Troubleshooting
-
-If you experience any issues during the deployment (for example if you experience a timeout), you can reattempt the deployment by running the upgrade command:
+Confirm `kubectl` is pointed at the right cluster:
 
 ```bash
-export HELM_RELEASE_NAME=$(helm list --all-namespaces | awk 'NR>1 {print $1}') && helm upgrade $HELM_RELEASE_NAME nvidia/gpu-operator -n gpu-operator
+kubectl get nodes
 ```
+
+You should see your cluster's nodes, including the GPU worker(s).
+
+### Install the Operator
+
+Civo's GPU images ship with the NVIDIA container toolkit already installed, so the Operator should **not** re-install it. Use the command below — the flags match how Civo's GPU images are built.
+
+:::note
+The flags and workarounds on this page have been validated against **NVIDIA GPU Operator chart v25.10.1** (app version v25.10.1). Newer chart versions should work with the same flags, but this is the version Civo has tested end-to-end. You can pin to it with `--version 25.10.1` on the `helm upgrade --install` command.
+:::
+
+```bash
+helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+helm repo update
+
+helm upgrade --install gpu-operator \
+  -n gpu-operator --create-namespace \
+  nvidia/gpu-operator \
+  --set driver.enabled=true \
+  --set toolkit.enabled=false \
+  --set devicePlugin.enabled=true \
+  --set gfd.enabled=true \
+  --set operator.defaultRuntime=containerd \
+  --set validator.cuda.runtimeClassName=nvidia
+```
+
+What each flag does:
+
+| Flag | Purpose |
+|------|---------|
+| `driver.enabled=true` | Let the Operator install the matching NVIDIA driver on the GPU node. |
+| `toolkit.enabled=false` | Skip container-toolkit install — it's already baked into the Civo image. |
+| `devicePlugin.enabled=true` | Expose GPUs to Kubernetes as schedulable resources (`nvidia.com/gpu`). |
+| `gfd.enabled=true` | Run GPU Feature Discovery so nodes are labelled with their GPU model and capabilities. |
+| `operator.defaultRuntime=containerd` | Use the `containerd` runtime that Civo Kubernetes ships with. |
+| `validator.cuda.runtimeClassName=nvidia` | Run the Operator's CUDA validator with the `nvidia` runtime class. |
+
+:::note
+You do not need to upgrade the Operator manually — it tracks newer driver versions and reconciles the node automatically.
+:::
+
+### Single-GPU H100 nodes: NVLink workaround
+
+On a node with **only one H100**, the NVIDIA driver tries to bring up NVLink at load time, fails (because there is no peer GPU to link with), and the driver never becomes ready. The fix is to disable NVLink in a small kernel-module config and pass it to the Operator at install time.
+
+Apply this **in addition to** the standard install above — it only affects driver loading, nothing else.
+
+1. Create a ConfigMap in the `gpu-operator` namespace that disables NVLink:
+
+   ```bash
+   kubectl create namespace gpu-operator --dry-run=client -o yaml | kubectl apply -f -
+
+   kubectl -n gpu-operator create configmap nvidia-kernel-config \
+     --from-literal=nvidia.conf='options nvidia NVreg_NvLinkDisable=1' \
+     --dry-run=client -o yaml | kubectl apply -f -
+   ```
+
+2. Install (or re-install) the Operator, adding `driver.kernelModuleConfig.name=nvidia-kernel-config` to the command from the previous section:
+
+   ```bash
+   helm upgrade --install gpu-operator \
+     -n gpu-operator --create-namespace \
+     nvidia/gpu-operator \
+     --set driver.enabled=true \
+     --set driver.kernelModuleConfig.name=nvidia-kernel-config \
+     --set toolkit.enabled=false \
+     --set devicePlugin.enabled=true \
+     --set gfd.enabled=true \
+     --set operator.defaultRuntime=containerd \
+     --set validator.cuda.runtimeClassName=nvidia
+   ```
+
+:::warning
+Only apply this workaround on **single-H100 nodes**. On multi-H100 nodes the GPUs use NVLink to talk to each other — disabling it will reduce peer-to-peer bandwidth between GPUs.
+:::
+
+### Verify the installation
+
+Check that the Operator pods are running:
+
+```bash
+kubectl -n gpu-operator get pods
+```
+
+![List GPU Operator pods in Kubernetes](../images/kubectl-list-gpu-operator.png)
+
+Then confirm the GPU node has been labelled with its GPU model and `nvidia.com/gpu.present=true`:
+
+```bash
+kubectl describe node <your-gpu-node>
+```
+
+![NVIDIA GPU node labels in Kubernetes](../images/k8s-gpu-node-label.png)
+
+Your cluster can now schedule pods that request `nvidia.com/gpu` resources.
+
+## Troubleshooting
+
+**A Helm install timed out.** Re-run the same `helm upgrade --install …` command — it is idempotent. If you prefer a one-liner that re-runs whichever release is already installed:
+
+```bash
+export HELM_RELEASE_NAME=$(helm list -n gpu-operator -q)
+helm upgrade $HELM_RELEASE_NAME nvidia/gpu-operator -n gpu-operator
+```
+
+**Driver pod on an H100 node is stuck in `CrashLoopBackOff` or `Init:Error`.** This is the NVLink issue described above. Follow [Single-GPU H100 nodes: NVLink workaround](#single-gpu-h100-nodes-nvlink-workaround), then run `kubectl -n gpu-operator rollout restart daemonset/nvidia-driver-daemonset` to pick up the new config.
+
+**Pods that request `nvidia.com/gpu` stay `Pending`.** Confirm the node has the label `nvidia.com/gpu.present=true` and that GPU Feature Discovery is running (`kubectl -n gpu-operator get pods -l app=gpu-feature-discovery`). If the labels are missing, the Operator hasn't finished provisioning the node yet — give it another minute or inspect the driver pod logs.


### PR DESCRIPTION
## Summary

Updates the GPU Clusters doc (`kubernetes/advanced/gpu-config.md`) so customers get a reliable install on first try on Civo's GPU image, and have clear guidance for the single-GPU H100 case that currently fails without a workaround.

## What changed

- **Install command tuned for Civo's image.** Replaced the bare `helm install --generate-name` snippet with a `helm upgrade --install` that passes `toolkit.enabled=false` (the NVIDIA container toolkit is already baked into Civo's GPU image), plus `driver.enabled=true`, `devicePlugin.enabled=true`, `gfd.enabled=true`, `operator.defaultRuntime=containerd`, and `validator.cuda.runtimeClassName=nvidia`. Added a table explaining what each flag does.
- **New section: Single-GPU H100 nodes — NVLink workaround.** On a node with only one H100, the driver fails to load because NVLink has no peer. Documented the `nvidia-kernel-config` ConfigMap with `NVreg_NvLinkDisable=1` and the matching `driver.kernelModuleConfig.name` helm flag. Includes a warning not to apply this on multi-H100 nodes.
- **B200 added** to the supported GPU list.
- **GPU Operator version pinned** — called out chart/app v25.10.1 as the version Civo has validated end-to-end, with a `--version 25.10.1` tip.
- **Troubleshooting expanded** — H100 `CrashLoopBackOff` now points at the NVLink section; added guidance for pods stuck `Pending` on `nvidia.com/gpu`.

## Why

The previous install example produced a working-but-suboptimal setup on Civo clusters (the Operator would layer its own container toolkit on top of the one Civo already provides), and single-GPU H100 nodes failed with no customer-facing explanation. These edits bring the doc in line with what our internal testing has validated.