### PR TITLE
docs(overview): add CivoCloudManager (community macOS client) to tools overview

### DIFF
--- a/content/docs/overview/tools-overview.md
+++ b/content/docs/overview/tools-overview.md
@@ -29,3 +29,18 @@ curl -sL https://civo.com/get | sh
 Civo has a Terraform provider, which can be found in the GitHub [Civo/terraform-provider-civo](https://github.com/civo/terraform-provider-civo) repository.
 
 Refer to the Civo [Terraform documentation](./terraform.md) on getting set up.
+
+## Community tools
+
+Beyond the official Civo CLI and Terraform provider, the community has built additional tools for managing Civo resources.
+
+### CivoCloudManager (macOS)
+
+[CivoCloudManager](https://civo-cloud-manager.app) is a native macOS application that runs the Civo Cloud control plane from the Mac menu bar and a full dashboard window. It talks to the [Civo REST API v2](https://www.civo.com/api) directly, connects to the Kubernetes API per cluster using PKCS#12 client certificates (no kubectl required), and ships a native S3-compatible browser for Civo Object Storage.
+
+- Website: [civo-cloud-manager.app](https://civo-cloud-manager.app)
+- Source: [github.com/marcelrgberger/civo-cloud-manager](https://github.com/marcelrgberger/civo-cloud-manager)
+- Mac App Store: [apps.apple.com/app/civocloudmanager/id6760776010](https://apps.apple.com/us/app/civocloudmanager/id6760776010?mt=12)
+- Free tier covers menu-bar firewall management; the full dashboard is a one-time $14.99 purchase.
+
+Built and maintained independently of Civo Ltd.


### PR DESCRIPTION
## What this PR does

Adds a "Community tools" section to the Civo tools overview that introduces CivoCloudManager, a community-built native macOS client for the Civo Cloud platform.

## Why

The current tools-overview page lists the Civo CLI and Terraform — both maintained by Civo. There is also a community-built GUI surface that fills a gap a CLI cannot: live Kubernetes pod logs, native S3 browser, menu-bar firewall toggling without an MFA loop. Mentioning it on the tools-overview page gives Mac-using Civo customers a discoverable native option without having to leave the docs.

## What is CivoCloudManager

A native macOS app distributed via the Mac App Store. Built independently of Civo Ltd.

- Website: https://civo-cloud-manager.app
- Source: https://github.com/marcelrgberger/civo-cloud-manager
- Mac App Store: https://apps.apple.com/us/app/civocloudmanager/id6760776010?mt=12

It talks to the documented Civo REST API v2 only — no proprietary backend in the loop, no telemetry, no analytics. Apple frameworks only (SwiftUI, CryptoKit, Security, LocalAuthentication).

Notable features:
- Menu-bar firewall (free tier): one-click open/close scoped to current IP, IP presets, auto-close timer.
- Full Kubernetes management with direct K8s API access (PKCS#12 mTLS, no kubectl).
- Live pod logs, pod exec, deployment scaling, ConfigMap/Secret viewer.
- S3-compatible Object Storage browser implemented natively (AWS SigV4 via CryptoKit, no AWS SDK).
- Object Store Pause/Resume — archive idle stores to a vault to save costs.
- Cost dashboard from the Civo charges API with month-end projection.
- Touch-ID-gated credential reveal.

## Disclosure

I am the author of CivoCloudManager. Happy to adjust the wording, move the section, shorten the entry, or split it into a dedicated "Community tools" sub-page — whatever fits your editorial preferences. If the addition is unwanted, I'll close the PR with no hard feelings.
